### PR TITLE
fix: versioned formulas

### DIFF
--- a/Formula/noto@1.3.0.rb
+++ b/Formula/noto@1.3.0.rb
@@ -1,4 +1,4 @@
-class Noto < Formula
+class NotoAT130 < Formula
   desc "Generate clean commit messages in a snap! ✨"
   homepage "https://noto.snelusha.dev"
   version "1.3.0"

--- a/Formula/noto@1.3.1.rb
+++ b/Formula/noto@1.3.1.rb
@@ -1,4 +1,4 @@
-class Noto < Formula
+class NotoAT131 < Formula
   desc "Generate clean commit messages in a snap! ✨"
   homepage "https://noto.snelusha.dev"
   version "1.3.1"

--- a/scripts/release.rb
+++ b/scripts/release.rb
@@ -49,7 +49,7 @@ unless versioned_formula.include?("keg_only")
 end
 
 versioned_class = "class NotoAT#{version.gsub(/\./, "")}"
-versioned_formula = formula.gsub(/class Bun/, versioned_class)
+versioned_formula = formula.gsub(/class Noto/, versioned_class)
 
 File.write("Formula/noto@#{version}.rb", versioned_formula)
 puts "Saved Formula/noto@#{version}.rb"


### PR DESCRIPTION
This pull request updates the naming convention for formula classes and fixes a script to ensure correct class names for versioned formula files. The most important changes are grouped below:

Formula class renaming:

* Renamed the class in `Formula/noto@1.3.0.rb` from `Noto` to `NotoAT130` to match versioned formula naming conventions.
* Renamed the class in `Formula/noto@1.3.1.rb` from `Noto` to `NotoAT131` for consistency with versioned formula naming.

Release script update:

* Updated the class name replacement in `scripts/release.rb` to use `Noto` instead of `Bun`, ensuring the script generates the correct versioned class name for new formula files.

Closes #5 